### PR TITLE
feat: implement GhppApi credentials and Ghpp node (#10)

### DIFF
--- a/credentials/GhppApi.credentials.ts
+++ b/credentials/GhppApi.credentials.ts
@@ -1,0 +1,28 @@
+import type { ICredentialTestRequest, ICredentialType, Icon, INodeProperties } from 'n8n-workflow';
+
+export class GhppApi implements ICredentialType {
+	name = 'ghppApi';
+	displayName = 'GHPP API';
+	documentationUrl = 'https://github.com/douhashi/n8n-nodes-ghpp';
+	icon: Icon = 'file:ghpp.svg';
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: 'https://api.github.com',
+			url: '/user',
+			headers: {
+				Authorization: '=Bearer {{$credentials.token}}',
+			},
+		},
+	};
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Token',
+			name: 'token',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			placeholder: 'ghp_xxxxxxxxxxxx',
+			description: 'GitHub Personal Access Token (repo + project scope)',
+		},
+	];
+}

--- a/credentials/ghpp.svg
+++ b/credentials/ghpp.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60">
+  <!-- Background -->
+  <rect width="60" height="60" rx="12" fill="#0F6E56"/>
+  <!-- Promote arrow (left to right across top) -->
+  <line x1="8" y1="12" x2="48" y2="12" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.8"/>
+  <path d="M44 9 L49 12 L44 15" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.8"/>
+  <!-- Column 1: inbox (faint) -->
+  <rect x="7"  y="20" width="13" height="30" rx="3" fill="white" opacity="0.25"/>
+  <rect x="9"  y="24" width="9" height="4" rx="1.5" fill="white" opacity="0.7"/>
+  <rect x="9"  y="30" width="9" height="4" rx="1.5" fill="white" opacity="0.5"/>
+  <rect x="9"  y="36" width="9" height="4" rx="1.5" fill="white" opacity="0.4"/>
+  <!-- Column 2: plan (medium) -->
+  <rect x="24" y="20" width="13" height="30" rx="3" fill="white" opacity="0.45"/>
+  <rect x="26" y="24" width="9" height="4" rx="1.5" fill="white" opacity="0.9"/>
+  <rect x="26" y="30" width="9" height="4" rx="1.5" fill="white" opacity="0.7"/>
+  <!-- Column 3: doing (bright) -->
+  <rect x="41" y="20" width="13" height="30" rx="3" fill="white" opacity="1"/>
+  <rect x="43" y="24" width="9" height="4" rx="1.5" fill="#0F6E56"/>
+</svg>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
-import { config } from '@n8n/node-cli/eslint';
+import { configWithoutCloudSupport } from '@n8n/node-cli/eslint';
 
 export default [
-	...config,
+	...configWithoutCloudSupport,
 	{
 		ignores: ['vitest.config.ts'],
 	},

--- a/nodes/Ghpp/Ghpp.node.test.ts
+++ b/nodes/Ghpp/Ghpp.node.test.ts
@@ -1,0 +1,130 @@
+import { execFile } from 'child_process';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { Ghpp } from './Ghpp.node';
+
+vi.mock('child_process', () => ({
+	execFile: vi.fn(),
+}));
+
+const mockedExecFile = vi.mocked(execFile);
+
+function createMockExecuteFunctions(overrides?: {
+	planLimit?: number;
+	statusSettings?: Record<string, string>;
+}): IExecuteFunctions {
+	const credentials = { token: 'ghp_test_token' };
+	const params: Record<string, unknown> = {
+		owner: 'test-org',
+		projectNumber: 42,
+		planLimit: overrides?.planLimit ?? 3,
+		statusSettings: overrides?.statusSettings ?? {},
+	};
+
+	return {
+		getCredentials: vi.fn().mockResolvedValue(credentials),
+		getInputData: vi.fn().mockReturnValue([{ json: {} }]),
+		getNodeParameter: vi.fn().mockImplementation((name: string) => params[name]),
+		getNode: vi.fn().mockReturnValue({ name: 'GHPP' }),
+	} as unknown as IExecuteFunctions;
+}
+
+describe('Ghpp.node', () => {
+	const ghpp = new Ghpp();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should parse JSON response from stdout', async () => {
+		const expected = { promoted: 3, items: ['a', 'b', 'c'] };
+		mockedExecFile.mockImplementation((_cmd, _args, callback: unknown) => {
+			(callback as (...args: unknown[]) => void)(null, {
+				stdout: JSON.stringify(expected),
+				stderr: '',
+			});
+			return undefined as never;
+		});
+
+		const mockFns = createMockExecuteFunctions();
+		const result = await ghpp.execute.call(mockFns);
+
+		expect(result).toEqual([[{ json: expected }]]);
+	});
+
+	it('should fallback to raw stdout when JSON parse fails', async () => {
+		const rawOutput = 'not-json-output';
+		mockedExecFile.mockImplementation((_cmd, _args, callback: unknown) => {
+			(callback as (...args: unknown[]) => void)(null, { stdout: rawOutput, stderr: '' });
+			return undefined as never;
+		});
+
+		const mockFns = createMockExecuteFunctions();
+		const result = await ghpp.execute.call(mockFns);
+
+		expect(result).toEqual([[{ json: { raw: rawOutput } }]]);
+	});
+
+	it('should throw NodeOperationError when execFile fails', async () => {
+		const stderrMsg = 'ghpp: authentication failed';
+		mockedExecFile.mockImplementation((_cmd, _args, callback: unknown) => {
+			const error = new Error('Command failed') as Error & { stderr: string };
+			error.stderr = stderrMsg;
+			(callback as (...args: unknown[]) => void)(error);
+			return undefined as never;
+		});
+
+		const mockFns = createMockExecuteFunctions();
+		await expect(ghpp.execute.call(mockFns)).rejects.toThrow(NodeOperationError);
+	});
+
+	it('should include --plan-limit and --status-* flags when non-default values are set', async () => {
+		mockedExecFile.mockImplementation((_cmd, _args, callback: unknown) => {
+			(callback as (...args: unknown[]) => void)(null, { stdout: '{}', stderr: '' });
+			return undefined as never;
+		});
+
+		const mockFns = createMockExecuteFunctions({
+			planLimit: 5,
+			statusSettings: {
+				statusInbox: 'Todo',
+				statusPlan: 'Planning',
+				statusReady: 'Approved',
+				statusDoing: 'Working',
+			},
+		});
+		await ghpp.execute.call(mockFns);
+
+		const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+		expect(callArgs).toContain('--plan-limit');
+		expect(callArgs).toContain('5');
+		expect(callArgs).toContain('--status-inbox');
+		expect(callArgs).toContain('Todo');
+		expect(callArgs).toContain('--status-plan');
+		expect(callArgs).toContain('Planning');
+		expect(callArgs).toContain('--status-ready');
+		expect(callArgs).toContain('Approved');
+		expect(callArgs).toContain('--status-doing');
+		expect(callArgs).toContain('Working');
+	});
+
+	it('should omit --plan-limit and --status-* flags when default values are used', async () => {
+		mockedExecFile.mockImplementation((_cmd, _args, callback: unknown) => {
+			(callback as (...args: unknown[]) => void)(null, { stdout: '{}', stderr: '' });
+			return undefined as never;
+		});
+
+		const mockFns = createMockExecuteFunctions();
+		await ghpp.execute.call(mockFns);
+
+		const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+		expect(callArgs).not.toContain('--plan-limit');
+		expect(callArgs).not.toContain('--status-inbox');
+		expect(callArgs).not.toContain('--status-plan');
+		expect(callArgs).not.toContain('--status-ready');
+		expect(callArgs).not.toContain('--status-doing');
+	});
+});

--- a/nodes/Ghpp/Ghpp.node.ts
+++ b/nodes/Ghpp/Ghpp.node.ts
@@ -1,0 +1,158 @@
+import { execFile } from 'child_process';
+import * as path from 'path';
+import { promisify } from 'util';
+
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+const execFileAsync = promisify(execFile);
+const binaryPath = path.join(__dirname, '../../bin/ghpp');
+
+export class Ghpp implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'GHPP',
+		name: 'ghpp',
+		icon: 'file:ghpp.svg',
+		group: ['transform'],
+		version: 1,
+		subtitle: 'ghpp promote',
+		description: 'Run ghpp promote to manage GitHub Project items',
+		defaults: { name: 'GHPP' },
+		usableAsTool: true,
+		inputs: ['main'],
+		outputs: ['main'],
+		credentials: [{ name: 'ghppApi', required: true }],
+		properties: [
+			{
+				displayName: 'Owner',
+				name: 'owner',
+				type: 'string',
+				required: true,
+				default: '',
+				placeholder: 'your-org-or-user',
+				description: 'GitHub owner (user or organization)',
+			},
+			{
+				displayName: 'Project Number',
+				name: 'projectNumber',
+				type: 'number',
+				required: true,
+				default: 0,
+				typeOptions: { minValue: 1 },
+				description: 'GitHub Project number',
+			},
+			{
+				displayName: 'Plan Limit',
+				name: 'planLimit',
+				type: 'number',
+				default: 3,
+				typeOptions: { minValue: 1 },
+				description: 'Maximum number of items to promote to Plan',
+			},
+			{
+				displayName: 'Status Settings',
+				name: 'statusSettings',
+				type: 'collection',
+				placeholder: 'Add Setting',
+				default: {},
+				options: [
+					{
+						displayName: 'Status Inbox',
+						name: 'statusInbox',
+						type: 'string',
+						default: 'Backlog',
+						description: 'Status name for inbox items',
+					},
+					{
+						displayName: 'Status Plan',
+						name: 'statusPlan',
+						type: 'string',
+						default: 'Plan',
+						description: 'Status name for planned items',
+					},
+					{
+						displayName: 'Status Ready',
+						name: 'statusReady',
+						type: 'string',
+						default: 'Ready',
+						description: 'Status name for ready items',
+					},
+					{
+						displayName: 'Status Doing',
+						name: 'statusDoing',
+						type: 'string',
+						default: 'In progress',
+						description: 'Status name for in-progress items',
+					},
+				],
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const credentials = await this.getCredentials('ghppApi');
+		const items = this.getInputData();
+		const returnData: INodeExecutionData[] = [];
+
+		for (let i = 0; i < items.length; i++) {
+			const owner = this.getNodeParameter('owner', i) as string;
+			const projectNumber = this.getNodeParameter('projectNumber', i) as number;
+			const planLimit = this.getNodeParameter('planLimit', i) as number;
+			const statusSettings = this.getNodeParameter('statusSettings', i) as {
+				statusInbox?: string;
+				statusPlan?: string;
+				statusReady?: string;
+				statusDoing?: string;
+			};
+
+			const args = [
+				'promote',
+				'--owner',
+				owner,
+				'--project-number',
+				String(projectNumber),
+				'--token',
+				String(credentials.token),
+			];
+
+			if (planLimit !== 3) {
+				args.push('--plan-limit', String(planLimit));
+			}
+
+			if (statusSettings.statusInbox !== undefined) {
+				args.push('--status-inbox', statusSettings.statusInbox);
+			}
+			if (statusSettings.statusPlan !== undefined) {
+				args.push('--status-plan', statusSettings.statusPlan);
+			}
+			if (statusSettings.statusReady !== undefined) {
+				args.push('--status-ready', statusSettings.statusReady);
+			}
+			if (statusSettings.statusDoing !== undefined) {
+				args.push('--status-doing', statusSettings.statusDoing);
+			}
+
+			try {
+				const { stdout } = await execFileAsync(binaryPath, args);
+				try {
+					const parsed = JSON.parse(stdout) as IDataObject;
+					returnData.push({ json: parsed });
+				} catch {
+					returnData.push({ json: { raw: stdout } });
+				}
+			} catch (error: unknown) {
+				const err = error as { stderr?: string; message?: string };
+				const message = err.stderr || err.message || 'Unknown error';
+				throw new NodeOperationError(this.getNode(), message);
+			}
+		}
+
+		return [returnData];
+	}
+}


### PR DESCRIPTION
Closes #10

## 変更内容

- `credentials/GhppApi.credentials.ts`: GhppApi Credentials 定義（token フィールド、GitHub API テスト接続、アイコン）
- `credentials/ghpp.svg`: Credentials 用アイコン（lint icon-validation 対応）
- `nodes/Ghpp/Ghpp.node.ts`: ノード本体（ghpp promote 実行、引数構築、JSON パース/フォールバック、エラーハンドリング）
- `nodes/Ghpp/Ghpp.node.test.ts`: ユニットテスト 5件（正常系2件、異常系1件、引数構築2件）
- `eslint.config.mjs`: `config` → `configWithoutCloudSupport` に変更（Node.js 組み込みモジュール使用のため）

## レビュー結果
内部レビュー通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)