### PR TITLE
feat: add release workflow for automated npm publish #17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+  release:
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify version consistency
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        run: gh release create ${{ github.ref_name }} --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.tmp
+++ b/.tmp
@@ -1,0 +1,1 @@
+/home/douhashi/ghq/github.com/douhashi/n8n-nodes-ghpp/.tmp

--- a/docs/operations/server.md
+++ b/docs/operations/server.md
@@ -28,3 +28,17 @@ Community Nodes として追加する場合:
 - ghpp バイナリは常に `latest` リリースを取得する
 - バージョンの固定は行わない
 - バイナリ更新が必要な場合は `bin/ghpp` を削除して `npm install` を再実行する
+
+## リリース手順
+
+GitHub Actions による自動リリースが構築されている。
+
+### 手順
+
+1. `npm version patch`（または `minor` / `major`）でバージョンを更新
+2. `git push origin main --tags` でタグを push
+3. GitHub Actions が自動的に以下を実行:
+   - CI チェック（lint / format / typecheck / test / build）
+   - バージョン整合性チェック
+   - npm publish
+   - GitHub Release 作成


### PR DESCRIPTION
Closes #17

## 変更内容
- `.github/workflows/release.yml` を新規作成: `v*` タグ push をトリガーに CI チェック → バージョン整合性検証 → npm publish → GitHub Release 作成を自動実行
- `docs/operations/server.md` にリリース手順セクションを追記

## ワークフロー構成
- **ci ジョブ**: 既存 ci.yml と同等ステップ（lint / format / typecheck / test / build）
- **release ジョブ** (needs: ci): バージョン整合性チェック → npm publish --access public → gh release create --generate-notes

## レビュー結果
内部レビュー通過済み