### PR TITLE
refactor: rename package from n8n-nodes-ghpp to n8n-node-ghpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# n8n-nodes-ghpp
+# n8n-node-ghpp
 
-[![npm version](https://img.shields.io/npm/v/n8n-nodes-ghpp.svg)](https://www.npmjs.com/package/n8n-nodes-ghpp)
+[![npm version](https://img.shields.io/npm/v/n8n-node-ghpp.svg)](https://www.npmjs.com/package/n8n-node-ghpp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Description
 
-**n8n-nodes-ghpp** is an n8n community node that runs [ghpp](https://github.com/douhashi/ghpp) (GitHub Project Promoter) from within n8n workflows.
+**n8n-node-ghpp** is an n8n community node that runs [ghpp](https://github.com/douhashi/ghpp) (GitHub Project Promoter) from within n8n workflows.
 
 ghpp automates status transitions in GitHub Projects V2 by promoting items through a defined flow:
 
@@ -25,14 +25,14 @@ inbox -> plan -> ready -> doing
 ### Via n8n Community Nodes (recommended)
 
 1. Open **Settings > Community Nodes** in your n8n instance.
-2. Search for `n8n-nodes-ghpp`.
+2. Search for `n8n-node-ghpp`.
 3. Click **Install**.
 
 ### Manual installation
 
 ```bash
 cd ~/.n8n/custom
-npm install n8n-nodes-ghpp
+npm install n8n-node-ghpp
 ```
 
 The `postinstall` script automatically downloads the appropriate `ghpp` binary from GitHub Releases. No additional setup is needed.
@@ -174,5 +174,5 @@ The ghpp binary is distributed under its own license. See [douhashi/ghpp](https:
 ## Resources
 
 - [ghpp repository](https://github.com/douhashi/ghpp) -- the underlying CLI tool
-- [n8n-nodes-ghpp repository](https://github.com/douhashi/n8n-nodes-ghpp) -- this package
+- [n8n-node-ghpp repository](https://github.com/douhashi/n8n-node-ghpp) -- this package
 - [n8n Community Nodes documentation](https://docs.n8n.io/integrations/community-nodes/)

--- a/credentials/GhppApi.credentials.ts
+++ b/credentials/GhppApi.credentials.ts
@@ -3,7 +3,7 @@ import type { ICredentialTestRequest, ICredentialType, Icon, INodeProperties } f
 export class GhppApi implements ICredentialType {
 	name = 'ghppApi';
 	displayName = 'GHPP API';
-	documentationUrl = 'https://github.com/douhashi/n8n-nodes-ghpp';
+	documentationUrl = 'https://github.com/douhashi/n8n-node-ghpp';
 	icon: Icon = 'file:ghpp.svg';
 	test: ICredentialTestRequest = {
 		request: {

--- a/docs/business/overview.md
+++ b/docs/business/overview.md
@@ -1,10 +1,10 @@
 # プロジェクト概要
 
-## n8n-nodes-ghpp とは
+## n8n-node-ghpp とは
 
-`n8n-nodes-ghpp` は、GitHub Projects V2 のステータス管理を自動化する CLI ツール [ghpp](https://github.com/douhashi/ghpp)（GitHub Project Promoter）を n8n のカスタムノードとして操作可能にする npm パッケージである。
+`n8n-node-ghpp` は、GitHub Projects V2 のステータス管理を自動化する CLI ツール [ghpp](https://github.com/douhashi/ghpp)（GitHub Project Promoter）を n8n のカスタムノードとして操作可能にする npm パッケージである。
 
-- **パッケージ名**: `n8n-nodes-ghpp`
+- **パッケージ名**: `n8n-node-ghpp`
 - **対象バイナリ**: [douhashi/ghpp](https://github.com/douhashi/ghpp)
 - **運用環境**: Docker（セルフホスト n8n）前提
 

--- a/docs/development/guideline.md
+++ b/docs/development/guideline.md
@@ -9,7 +9,7 @@
 ## ディレクトリ構成
 
 ```
-n8n-nodes-ghpp/
+n8n-node-ghpp/
 ├── nodes/
 │   └── Ghpp/
 │       ├── Ghpp.node.ts          # ノード本体

--- a/docs/operations/server.md
+++ b/docs/operations/server.md
@@ -19,7 +19,7 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/') && \
 
 Community Nodes として追加する場合:
 
-1. n8n の「Settings > Community Nodes」から `n8n-nodes-ghpp` をインストール
+1. n8n の「Settings > Community Nodes」から `n8n-node-ghpp` をインストール
 2. `postinstall` スクリプトが自動的に ghpp バイナリをダウンロード
 3. n8n を再起動
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "n8n-nodes-ghpp",
+	"name": "n8n-node-ghpp",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "n8n-nodes-ghpp",
+			"name": "n8n-node-ghpp",
 			"version": "0.1.0",
 			"hasInstallScript": true,
 			"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-	"name": "n8n-nodes-ghpp",
+	"name": "n8n-node-ghpp",
 	"version": "0.1.0",
 	"description": "n8n community node for ghpp (GitHub Project Promoter)",
 	"license": "MIT",
-	"homepage": "https://github.com/douhashi/n8n-nodes-ghpp",
+	"homepage": "https://github.com/douhashi/n8n-node-ghpp",
 	"keywords": [
 		"n8n-community-node-package"
 	],
@@ -12,7 +12,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/douhashi/n8n-nodes-ghpp.git"
+		"url": "https://github.com/douhashi/n8n-node-ghpp.git"
 	},
 	"scripts": {
 		"build": "n8n-node build",


### PR DESCRIPTION
## Summary
- パッケージ名を `n8n-nodes-ghpp` から `n8n-node-ghpp` に変更
- package.json, README, credentials, docs 全体で一括リネーム

## Test plan
- [x] pre-commit hook (lint / format / typecheck) パス
- [x] pre-push hook (test / build) パス
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)