### PR TITLE
Implement #28

### DIFF
--- a/docs/development/guideline.md
+++ b/docs/development/guideline.md
@@ -59,12 +59,19 @@ n8n-nodes-gh-project-promoter/
 
 ### 基本情報
 
-| 項目     | 値             |
-| -------- | -------------- |
-| 表示名   | GHPP           |
-| name     | ghpp           |
-| グループ | transform      |
-| コマンド | `ghpp promote` |
+| 項目     | 値                             |
+| -------- | ------------------------------ |
+| 表示名   | GHPP                           |
+| name     | ghpp                           |
+| グループ | transform                      |
+| コマンド | `ghpp promote` / `ghpp demote` |
+
+### Operation
+
+| 値        | 説明                                                |
+| --------- | --------------------------------------------------- |
+| `promote` | Issue アイテムを次のステータスに昇格させる          |
+| `demote`  | 停滞した Issue アイテムを前のステータスに降格させる |
 
 ### 必須パラメータ
 
@@ -75,9 +82,11 @@ n8n-nodes-gh-project-promoter/
 
 ### 任意パラメータ
 
-| 表示名     | name        | 型     | デフォルト | 対応オプション |
-| ---------- | ----------- | ------ | ---------- | -------------- |
-| Plan Limit | `planLimit` | number | `3`        | `--plan-limit` |
+| 表示名          | name             | 型      | デフォルト | 対応オプション      | 表示条件         |
+| --------------- | ---------------- | ------- | ---------- | ------------------- | ---------------- |
+| Plan Limit      | `planLimit`      | number  | `3`        | `--plan-limit`      | promote 時のみ   |
+| Stale Threshold | `staleThreshold` | string  | `2h`       | `--stale-threshold` | demote 時のみ    |
+| Dry Run         | `dryRun`         | boolean | `false`    | `--dry-run`         | 共通（常に表示） |
 
 ### ステータス設定（collection 型: Status Settings）
 
@@ -90,7 +99,7 @@ n8n-nodes-gh-project-promoter/
 
 ### 出力
 
-- `ghpp promote` の stdout を JSON パースして後続ノードの `json` フィールドに渡す
+- `ghpp promote` / `ghpp demote` の stdout を JSON パースして後続ノードの `json` フィールドに渡す
 - JSON パース失敗時は `{ raw: "..." }` にフォールバック
 
 ### エラーハンドリング

--- a/nodes/Ghpp/Ghpp.node.test.ts
+++ b/nodes/Ghpp/Ghpp.node.test.ts
@@ -22,14 +22,20 @@ vi.mock('fs', async (importOriginal) => {
 const mockedExecFile = vi.mocked(execFile);
 
 function createMockExecuteFunctions(overrides?: {
+	operation?: string;
 	planLimit?: number;
+	staleThreshold?: string;
+	dryRun?: boolean;
 	statusSettings?: Record<string, string>;
 }): IExecuteFunctions {
 	const credentials = { token: 'ghp_test_token' };
 	const params: Record<string, unknown> = {
+		operation: overrides?.operation ?? 'promote',
 		owner: 'test-org',
 		projectNumber: 42,
 		planLimit: overrides?.planLimit ?? 3,
+		staleThreshold: overrides?.staleThreshold ?? '2h',
+		dryRun: overrides?.dryRun ?? false,
 		statusSettings: overrides?.statusSettings ?? {},
 	};
 
@@ -41,6 +47,13 @@ function createMockExecuteFunctions(overrides?: {
 	} as unknown as IExecuteFunctions;
 }
 
+function setupExecFileSuccess(stdout = '{}') {
+	mockedExecFile.mockImplementation((_cmd, _args, callback: unknown) => {
+		(callback as (...args: unknown[]) => void)(null, { stdout, stderr: '' });
+		return undefined as never;
+	});
+}
+
 describe('Ghpp.node', () => {
 	const ghpp = new Ghpp();
 
@@ -50,13 +63,7 @@ describe('Ghpp.node', () => {
 
 	it('should parse JSON response from stdout', async () => {
 		const expected = { promoted: 3, items: ['a', 'b', 'c'] };
-		mockedExecFile.mockImplementation((_cmd, _args, callback: unknown) => {
-			(callback as (...args: unknown[]) => void)(null, {
-				stdout: JSON.stringify(expected),
-				stderr: '',
-			});
-			return undefined as never;
-		});
+		setupExecFileSuccess(JSON.stringify(expected));
 
 		const mockFns = createMockExecuteFunctions();
 		const result = await ghpp.execute.call(mockFns);
@@ -91,10 +98,7 @@ describe('Ghpp.node', () => {
 	});
 
 	it('should include --plan-limit and --status-* flags when non-default values are set', async () => {
-		mockedExecFile.mockImplementation((_cmd, _args, callback: unknown) => {
-			(callback as (...args: unknown[]) => void)(null, { stdout: '{}', stderr: '' });
-			return undefined as never;
-		});
+		setupExecFileSuccess();
 
 		const mockFns = createMockExecuteFunctions({
 			planLimit: 5,
@@ -121,10 +125,7 @@ describe('Ghpp.node', () => {
 	});
 
 	it('should omit --plan-limit and --status-* flags when default values are used', async () => {
-		mockedExecFile.mockImplementation((_cmd, _args, callback: unknown) => {
-			(callback as (...args: unknown[]) => void)(null, { stdout: '{}', stderr: '' });
-			return undefined as never;
-		});
+		setupExecFileSuccess();
 
 		const mockFns = createMockExecuteFunctions();
 		await ghpp.execute.call(mockFns);
@@ -135,5 +136,72 @@ describe('Ghpp.node', () => {
 		expect(callArgs).not.toContain('--status-plan');
 		expect(callArgs).not.toContain('--status-ready');
 		expect(callArgs).not.toContain('--status-doing');
+	});
+
+	it('should use demote as first arg when operation is demote', async () => {
+		setupExecFileSuccess();
+
+		const mockFns = createMockExecuteFunctions({ operation: 'demote' });
+		await ghpp.execute.call(mockFns);
+
+		const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+		expect(callArgs[0]).toBe('demote');
+		expect(callArgs).not.toContain('--plan-limit');
+	});
+
+	it('should include --stale-threshold when demote with non-default value', async () => {
+		setupExecFileSuccess();
+
+		const mockFns = createMockExecuteFunctions({
+			operation: 'demote',
+			staleThreshold: '30m',
+		});
+		await ghpp.execute.call(mockFns);
+
+		const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+		expect(callArgs).toContain('--stale-threshold');
+		expect(callArgs).toContain('30m');
+	});
+
+	it('should omit --stale-threshold when demote with default value', async () => {
+		setupExecFileSuccess();
+
+		const mockFns = createMockExecuteFunctions({ operation: 'demote' });
+		await ghpp.execute.call(mockFns);
+
+		const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+		expect(callArgs).not.toContain('--stale-threshold');
+	});
+
+	it('should include --dry-run when dryRun is true for promote', async () => {
+		setupExecFileSuccess();
+
+		const mockFns = createMockExecuteFunctions({ operation: 'promote', dryRun: true });
+		await ghpp.execute.call(mockFns);
+
+		const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+		expect(callArgs[0]).toBe('promote');
+		expect(callArgs).toContain('--dry-run');
+	});
+
+	it('should omit --dry-run when dryRun is false for promote', async () => {
+		setupExecFileSuccess();
+
+		const mockFns = createMockExecuteFunctions({ operation: 'promote', dryRun: false });
+		await ghpp.execute.call(mockFns);
+
+		const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+		expect(callArgs).not.toContain('--dry-run');
+	});
+
+	it('should include --dry-run when dryRun is true for demote', async () => {
+		setupExecFileSuccess();
+
+		const mockFns = createMockExecuteFunctions({ operation: 'demote', dryRun: true });
+		await ghpp.execute.call(mockFns);
+
+		const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+		expect(callArgs[0]).toBe('demote');
+		expect(callArgs).toContain('--dry-run');
 	});
 });

--- a/nodes/Ghpp/Ghpp.node.ts
+++ b/nodes/Ghpp/Ghpp.node.ts
@@ -109,14 +109,35 @@ export class Ghpp implements INodeType {
 		icon: 'file:ghpp.svg',
 		group: ['transform'],
 		version: 1,
-		subtitle: 'ghpp promote',
-		description: 'Run ghpp promote to manage GitHub Project items',
+		subtitle: '={{$parameter["operation"] === "demote" ? "ghpp demote" : "ghpp promote"}}',
+		description: 'Run ghpp promote/demote to manage GitHub Project Issue items',
 		defaults: { name: 'GHPP' },
 		usableAsTool: true,
 		inputs: ['main'],
 		outputs: ['main'],
 		credentials: [{ name: 'ghppApi', required: true }],
 		properties: [
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Promote',
+						value: 'promote',
+						description: 'Promote Issue items to the next status',
+						action: 'Promote issue items to the next status',
+					},
+					{
+						name: 'Demote',
+						value: 'demote',
+						description: 'Demote stale Issue items to the previous status',
+						action: 'Demote stale issue items to the previous status',
+					},
+				],
+				default: 'promote',
+			},
 			{
 				displayName: 'Owner',
 				name: 'owner',
@@ -142,6 +163,30 @@ export class Ghpp implements INodeType {
 				default: 3,
 				typeOptions: { minValue: 1 },
 				description: 'Maximum number of items to promote to Plan',
+				displayOptions: {
+					show: {
+						operation: ['promote'],
+					},
+				},
+			},
+			{
+				displayName: 'Stale Threshold',
+				name: 'staleThreshold',
+				type: 'string',
+				default: '2h',
+				description: 'Duration threshold for considering an item stale (e.g. "2h", "30m")',
+				displayOptions: {
+					show: {
+						operation: ['demote'],
+					},
+				},
+			},
+			{
+				displayName: 'Dry Run',
+				name: 'dryRun',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to run in dry-run mode (no changes will be made)',
 			},
 			{
 				displayName: 'Status Settings',
@@ -199,9 +244,10 @@ export class Ghpp implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 
 		for (let i = 0; i < items.length; i++) {
+			const operation = this.getNodeParameter('operation', i) as string;
 			const owner = this.getNodeParameter('owner', i) as string;
 			const projectNumber = this.getNodeParameter('projectNumber', i) as number;
-			const planLimit = this.getNodeParameter('planLimit', i) as number;
+			const dryRun = this.getNodeParameter('dryRun', i) as boolean;
 			const statusSettings = this.getNodeParameter('statusSettings', i) as {
 				statusInbox?: string;
 				statusPlan?: string;
@@ -210,7 +256,7 @@ export class Ghpp implements INodeType {
 			};
 
 			const args = [
-				'promote',
+				operation,
 				'--owner',
 				owner,
 				'--project-number',
@@ -219,8 +265,22 @@ export class Ghpp implements INodeType {
 				String(credentials.token),
 			];
 
-			if (planLimit !== 3) {
-				args.push('--plan-limit', String(planLimit));
+			if (operation === 'promote') {
+				const planLimit = this.getNodeParameter('planLimit', i) as number;
+				if (planLimit !== 3) {
+					args.push('--plan-limit', String(planLimit));
+				}
+			}
+
+			if (operation === 'demote') {
+				const staleThreshold = this.getNodeParameter('staleThreshold', i) as string;
+				if (staleThreshold !== '2h') {
+					args.push('--stale-threshold', staleThreshold);
+				}
+			}
+
+			if (dryRun) {
+				args.push('--dry-run');
 			}
 
 			if (statusSettings.statusInbox !== undefined) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"bin"
 	],
 	"ghpp": {
-		"version": "0.3.1"
+		"version": "0.4.1"
 	},
 	"n8n": {
 		"n8nNodesApiVersion": 1,


### PR DESCRIPTION
Closes #28

## 変更内容
- ghpp CLI バージョンを v0.3.1 → v0.4.1 に更新
- Operation パラメータ（promote / demote）を追加し、サブコマンドを選択可能に
- demote 専用パラメータ `staleThreshold`（デフォルト "2h"）を追加
- 共通パラメータ `dryRun`（boolean）を追加
- `planLimit` は promote 時のみ、`staleThreshold` は demote 時のみ表示（displayOptions 制御）
- subtitle を Operation に応じて動的切り替え
- テスト 6件追加（計 22 テスト通過）
- ドキュメント（guideline.md）を新パラメータ・コマンドに合わせて更新

## レビュー結果
内部レビュー通過済み